### PR TITLE
Fixed TP-Link regexp to match routers without version

### DIFF
--- a/_plugins/firmwares.rb
+++ b/_plugins/firmwares.rb
@@ -180,7 +180,7 @@ GROUPS = {
       "CPE220",
       "CPE510",
       "CPE520",
-      # geht nicht wegen keiner version: "RE450",
+      "RE450",
       "TL-WA7210N",
       "TL-WA730RE",
       "TL-WR1043N",
@@ -218,7 +218,7 @@ GROUPS = {
       "TL-WR941N/ND",
     ],
     #            lambda macht nur, dass es jedes mal ausgeführt wird
-    extract_rev: lambda { |model, suffix| rev = /^-(.+?)(?:-sysupgrade)?\.bin$/.match(suffix)[1] },
+    extract_rev: lambda { |model, suffix| rev = /^(?:-(?!sysupgrade)(.+?))?(?:-sysupgrade)?\.bin$/.match(suffix)[1] },
   },
   "Ubnt" => {
     models: [


### PR DESCRIPTION
The TP-Link RE450 filename broke the matching due to missing version number.
Making the initial dash optional makes jekyll run again, but then matches the version against "sysupgrade". This regexp should match correctly for all TP-Link routers.